### PR TITLE
The command zopeedit will work even when installed using pip

### DIFF
--- a/collective/zopeedit/zopeedit.py
+++ b/collective/zopeedit/zopeedit.py
@@ -41,6 +41,7 @@ import glob
 import locale
 import logging
 import os
+import pkg_resources
 import re
 import rfc822
 import shutil
@@ -60,22 +61,8 @@ try:
 except NameError:
     system_path = os.path.realpath(os.path.dirname(sys.argv[0]))
 
-# Open the VERSION file for reading.
-if os.path.exists(os.path.join(system_path, "docs/VERSION.txt")):
-    f = open(os.path.join(system_path, "docs/VERSION.txt"), "r")
-elif os.path.exists(os.path.join(system_path, "../../docs/VERSION.txt")):
-    # zopeedit is not properly installed : try uninstalled path
-    f = open(os.path.join(system_path, "../../docs/VERSION.txt"), "r")
-elif os.path.exists(os.path.join(system_path, "collective/zopeedit/docs/VERSION.txt")):
-    f = open(os.path.join(system_path, "collective/zopeedit/docs/VERSION.txt"), "r")
-else:
-    f = None
 
-if f is not None:
-    __version__ = f.readline()[:-1]
-else:
-    __version__ = "0"
-f.close()
+__version__ = pkg_resources.get_distribution("collective.zopeedit").version
 
 
 # Where am i ?

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 (Unreleased) - 1.1.0
 --------------------
 
+    - The command zopeedit will work even when installed using pip. Fixes #9 (ale-rt)
     - Fix --help (ale-rt)
     - fixed file closing detection under MacOSX (thomasdesvenain)
     - zopeedit client works if fuser is located in /usr/bin folder.


### PR DESCRIPTION
The code was trying hard to find the version of the package which is saved in a `VERSION.txt` file which is not present in a regular pip installation.
That is fixed by checking the package version using `pkg_resources`.

Fixes #9