### PR TITLE
Do not raise an exception (and exit), if `fuser` is not found

### DIFF
--- a/collective/zopeedit/zopeedit.py
+++ b/collective/zopeedit/zopeedit.py
@@ -1663,11 +1663,14 @@ class EditorProcess:
         return False
 
     def isFileOpen(self):
-        """Test if File is locked (filesystem)"""
-        logger.debug("test if the file edited is locked by filesystem")
-        command = "/bin/fuser"
-        if not os.path.exists(command):
-            command = "/usr/bin/fuser"
+        """Test if File is opened (system)"""
+        logger.debug("test if the file edited is opened by the editor...")
+
+        for command in ['/bin/fuser', '/usr/bin/fuser', '/usr/sbin/fuser']:
+            if os.path.exists(command):
+                break
+        else:
+            return False
 
         process = Popen([command, self.command.split(" ")[-1]], stdout=subprocess.PIPE)
         process.wait()

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,8 @@ Changelog
 (Unreleased) - 1.1.0
 --------------------
 
+    - Look for the "fuser" command in .../sbin too. Also,
+      do not crash when fuser isnt found. Fixes #12 (wlang42)
     - The command zopeedit will work even when installed using pip. Fixes #9 (ale-rt)
     - Fix --help (ale-rt)
     - fixed file closing detection under MacOSX (thomasdesvenain)


### PR DESCRIPTION
Fix Issue #12