### PR TITLE
Sometimes the zem cannot be deleted because it's considered locked by a process (on Windows here)

### DIFF
--- a/collective/zopeedit/win32/ZopeEdit.ini
+++ b/collective/zopeedit/win32/ZopeEdit.ini
@@ -2,7 +2,7 @@
 
 [general]
 # General configuration options
-version = 1.1.2
+version = 1.2.0
 
 # Temporary file cleanup. Set to false for debugging or
 # to waste disk space. Note: setting this to false is a

--- a/collective/zopeedit/win32/ZopeEdit.ini
+++ b/collective/zopeedit/win32/ZopeEdit.ini
@@ -2,7 +2,7 @@
 
 [general]
 # General configuration options
-version = 1.1.0
+version = 1.1.2
 
 # Temporary file cleanup. Set to false for debugging or
 # to waste disk space. Note: setting this to false is a

--- a/collective/zopeedit/zopeedit.py
+++ b/collective/zopeedit/zopeedit.py
@@ -273,6 +273,7 @@ class ExternalEditor:
                 self.metadata["content_type"] = self.dexterity.get(
                     "Content-Type", self.metadata.get("content_type", "text/plain")
                 )
+                in_f.close()  # to avoid a problem when deleting original zem file
                 in_f = StringIO.StringIO()
                 in_f.write(msg.get_payload(decode=True))
                 in_f.seek(0)

--- a/collective/zopeedit/zopeedit.py
+++ b/collective/zopeedit/zopeedit.py
@@ -273,7 +273,7 @@ class ExternalEditor:
                 self.metadata["content_type"] = self.dexterity.get(
                     "Content-Type", self.metadata.get("content_type", "text/plain")
                 )
-                in_f.close()  # to avoid a problem when deleting original zem file
+                in_f.close()  # to avoid problem when deleting original zem file
                 in_f = StringIO.StringIO()
                 in_f.write(msg.get_payload(decode=True))
                 in_f.seek(0)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,8 +4,7 @@ Changelog
 1.2.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+    - Close zem file before overriding file handler variable, so it can be correctly deleted (sgeulette)
 
 1.1.2 (2022-01-26)
 ------------------


### PR DESCRIPTION
Now the file handler is well closed in all cases.